### PR TITLE
Improve the readability of the status bar functions

### DIFF
--- a/sc/source/ui/view/tabvwsha.cxx
+++ b/sc/source/ui/view/tabvwsha.cxx
@@ -110,7 +110,7 @@ bool ScTabViewShell::GetFunction( OUString& rFuncStr, sal_uInt16 nErrCode )
             SCTAB       nTab        = rViewData.GetTabNo();
 
             aStr = ScGlobal::GetRscString(nGlobStrId);
-            aStr += "=";
+            aStr += ": ";
 
             ScAddress aCursor( nPosX, nPosY, nTab );
             double nVal;
@@ -141,7 +141,7 @@ bool ScTabViewShell::GetFunction( OUString& rFuncStr, sal_uInt16 nErrCode )
                 bFirst = false;
             }
             else
-                rFuncStr += (";" + aStr);
+                rFuncStr += ("    " + aStr);
         }
     }
 


### PR DESCRIPTION
This is like it was proposed in the feature request recently:
https://bugs.documentfoundation.org/show_bug.cgi?id=42629#c27

Currently there is no spacing between functions in the status bar. Which makes it hard to read. E.g.

```
Average=4.5;Count=8;Max=8;Sum=36
```

I think quadruple-spacing and using colons works out better:

```
Average: 4.5    Count: 8    Max: 8    Sum: 36
```
